### PR TITLE
feat(nixos): enable system-level fish support

### DIFF
--- a/modules/common/nixos.nix
+++ b/modules/common/nixos.nix
@@ -10,6 +10,8 @@ in {
   environment.variables = common.commonVariables;
   environment.shellAliases = common.shellAliases;
 
+  programs.fish.enable = true;
+
   users.users.${config.user} = lib.mkIf (config ? user) {
     home = lib.mkIf (config ? home) config.home;
     shell = pkgs.fish;


### PR DESCRIPTION
## Summary
- Add `programs.fish.enable = true` to NixOS module for consistency with Darwin configuration
- Ensures proper PAM authentication and system-level fish features on NixOS systems

Resolves #8